### PR TITLE
统一 git 的文件行尾

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿* text=auto eol=lf


### PR DESCRIPTION
通过添加 `.gitattribute` 文件，统一 git 提交时的行尾为 LF (据说跨平台兼容性更好)